### PR TITLE
Update single-verify command in README.rs

### DIFF
--- a/README.rs
+++ b/README.rs
@@ -25,5 +25,5 @@ cargo build --release
 cd zkWasm
 RUST_LOG=info cargo run --release -- --function zkmain --output ./output --wasm ../demo.wasm setup
 RUST_LOG=info cargo run --release -- --function zkmain --output ./output --wasm ../demo.wasm single-prove --public 3:i64 --private 1:i64 --private 2:i64
-RUST_LOG=info cargo run --release -- --function zkmain --output ./output --wasm ../demo.wasm single-verify --public 3:i64 --proof output/zkwasm.0.transcript.data
+RUST_LOG=info cargo run --release -- --function zkmain --output ./output --wasm ../demo.wasm single-verify
 ```


### PR DESCRIPTION
Parameters of single-verify were removed in https://github.com/DelphinusLab/zkWasm/commit/c26de2182eb481dad7f6affb30b55f0bb529bd2b. This change brings the instruction up-to-date.

Execution succeeded without paramters:
~/Documents/web3/zkwasm/zkWasm$RUST_LOG=info cargo run --release -- --function zkmain --output ./output --wasm ../zkWasm-AssemblyScript-Demo/demo.wasm single-verify                           
    Finished release [optimized] target(s) in 0.31s
     Running `target/release/delphinus-cli --function zkmain --output ./output --wasm ../zkWasm-AssemblyScript-Demo/demo.wasm single-verify`
[2024-01-07T23:49:46Z INFO  delphinus_cli::app_builder] param path is not provided, set to 5F15FE68490DBEF9A93BAD8BD94C1A67 [2024-01-07T23:49:46Z INFO  circuits_batcher::proof] read proof load info "./output/zkwasm.loadinfo.json" [2024-01-07T23:49:46Z INFO  circuits_batcher::proof] read vkey full from "5F15FE68490DBEF9A93BAD8BD94C1A67/zkwasm.circuit.data" quotient_poly_degree 4
read instance from "./output/zkwasm.0.instance.data" read transcript from "./output/zkwasm.0.transcript.data" read params K=18 from "5F15FE68490DBEF9A93BAD8BD94C1A67/K18.params" [2024-01-07T23:49:49Z INFO  delphinus_cli::exec] Verifing proof passed